### PR TITLE
Add package_ext to customize package extension for windows/other os

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Following variables are available to customize the URL:
 * `{{platform}}`: `$GOOS` value for the platform
 * `{{arch}}`: `$GOARCH` value for the architecture
 * `{{win_ext}}`: optional `.exe` extension for windows assets.
+* `{{package_ext}}`: `.zip` extension for Windows and `.tar.gz` for everything else.
 
 If you use `goreleaser` to publish your modules, it will automatically set the right architecture & platform in your URL.
 

--- a/src/common.js
+++ b/src/common.js
@@ -19,6 +19,14 @@ const PLATFORM_MAPPING = {
   freebsd: 'freebsd'
 };
 
+// Mapping between Node's `process.platform` to extensions
+const EXTENSION_MAPPING = {
+  darwin: '.tar.gz',
+  linux: '.tar.gz',
+  win32: '.zip',
+  freebsd: '.tar.gz'
+};
+
 function getInstallationPath(callback) {
 
   // `npm bin` might output the path where binary files should be installed
@@ -162,6 +170,7 @@ function parsePackageJson() {
   url = url.replace(/{{platform}}/g, PLATFORM_MAPPING[process.platform]);
   url = url.replace(/{{version}}/g, version);
   url = url.replace(/{{bin_name}}/g, binName);
+  url = url.replace(/{{package_ext}}/g, EXTENSION_MAPPING[process.platform]);
 
   return {
     binName,


### PR DESCRIPTION
I'm trying to do npm install of https://github.com/boardzilla/boardzilla-devtools/blob/main/package.json on Windows machine, and getting an error 
```
npm ERR! Downloading from URL: https://github.com/boardzilla/boardzilla-devtools/releases/download/v0.0.56/boardzilla-devtools_windows_amd64.tar.gz
npm ERR! Error downloading binary. HTTP Status Code: 404
```

I suppose it's because for windows OS it should have `.zip` extension, which is not currently supported. Introducing it in the PR.

Note: Review with caution, haven't had a chance to test it. 