### PR TITLE
Use `npm root` to find directory to place .bin

### DIFF
--- a/__test__/common.spec.js
+++ b/__test__/common.spec.js
@@ -21,12 +21,12 @@ describe('common', () => {
       process.env = env;
     });
 
-    it('should get binaries path from `npm bin`', () => {
-      childProcess.exec.mockImplementationOnce((_cmd, cb) => cb(null, path.sep + path.join('usr', 'local', 'bin')));
+    it('should get binaries path from `npm root`', () => {
+      childProcess.exec.mockImplementationOnce((_cmd, cb) => cb(null, path.sep + path.join('usr', 'local')));
 
       common.getInstallationPath(callback);
 
-      expect(callback).toHaveBeenCalledWith(null, path.sep + path.join('usr', 'local', 'bin'));
+      expect(callback).toHaveBeenCalledWith(null, path.sep + path.join('usr', 'local', '.bin'));
     });
 
     it('should get binaries path from env npm_config_prefix', () => {
@@ -47,7 +47,7 @@ describe('common', () => {
 
       common.getInstallationPath(callback);
 
-      expect(callback).toHaveBeenCalledWith(null, '/hello/there/node_modules/.bin');
+      expect(callback).toHaveBeenCalledWith(null, path.sep + path.join('hello', 'there', 'node_modules', '.bin'));
     });
 
     it('should call callback with error if binaries path is not found', () => {

--- a/src/common.js
+++ b/src/common.js
@@ -29,20 +29,11 @@ const EXTENSION_MAPPING = {
 
 function getInstallationPath(callback) {
 
-  // `npm bin` might output the path where binary files should be installed
-  // but in the case of running yarn, we should use that instead
-  let packageManager = 'npm';
-  if (process.env.npm_config_user_agent) {
-    const match = process.env.npm_config_user_agent.match("^[^\/]+");
-    if (match) {
-      packageManager = match[0];
-    }
-  }
-
-  exec(`${packageManager} bin`, function(err, stdout, stderr) {
+  // `npm root' will output the node_modules directory
+  exec(`npm root`, function(err, stdout, stderr) {
     let dir = null;
     if (err) {
-      // We couldn't infer path from `npm|yarn bin`.
+      // We couldn't infer path from `npm root`.
       // Let's try to get it from env. Either we'll use
       // PWD or npm_config_prefix
       const env = process.env;
@@ -59,7 +50,7 @@ function getInstallationPath(callback) {
         );
       }
     } else {
-      dir = stdout.trim();
+      dir = join(stdout.trim(), '.bin');
     }
 
     dir = dir.replace(/node_modules.*[\/\\]\.bin/, join('node_modules', '.bin'));


### PR DESCRIPTION
The `npm bin` command was removed in npm 9+ (https://github.com/codesuki/add-node-modules-path/issues/23) so using this method to detect the .bin directory fails for up-to-date node installations. On Linux, the `env.PWD` fallback appears to work. However, this approach does not work for Windows.

This PR proposes using the `npm root` command instead. This is a recommended workaround in the GitHub issue linked above. This should resolve disparities between installing @boardzilla/devtools using npm vs. yarn (where yarn still has a `yarn bin` command).