### PR TITLE
Migrate to unzip-stream to avoid breaking change in unzipper

### DIFF
--- a/__test__/assets/unzip.spec.js
+++ b/__test__/assets/unzip.spec.js
@@ -1,8 +1,8 @@
 const { EventEmitter } = require('events');
-const unzipper = require('unzipper');
+const unzipStream = require('unzip-stream');
 const unzip = require('../../src/assets/unzip');
 
-jest.mock('unzipper', () => ({
+jest.mock('unzip-stream', () => ({
   Extract: jest.fn()
 }));
 
@@ -18,14 +18,14 @@ describe('unzip()', () => {
     onError = jest.fn();
 
     pipe.mockReturnValueOnce({ pipe });
-    unzipper.Extract.mockReturnValueOnce(unzipEvents);
+    unzipStream.Extract.mockReturnValueOnce(unzipEvents);
   });
 
   it('should download resource and unzip to given binPath', () => {
 
     unzip({ opts: { binPath: './bin', binName: 'command' }, req: { pipe }, onSuccess, onError });
 
-    expect(unzipper.Extract).toHaveBeenCalledWith({ path: './bin' });
+    expect(unzipStream.Extract).toHaveBeenCalledWith({ path: './bin' });
   });
 
   it('should call onSuccess on unzip close', () => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "request": "^2.88.2",
     "tar": "^2.2.2",
-    "unzipper": "0.10.10"
+    "unzip-stream": "^0.3.1"
   },
   "devDependencies": {
     "esbuild": "^0.12.17",

--- a/src/assets/unzip.js
+++ b/src/assets/unzip.js
@@ -1,4 +1,4 @@
-const unzipper = require('unzipper');
+const unzipStream = require('unzip-stream');
 
 /**
  * Unzip strategy for resources using `.zip`.
@@ -8,7 +8,7 @@ const unzipper = require('unzipper');
  */
 function unzip({ opts, req, onSuccess, onError }) {
 
-  const unzip = unzipper.Extract({ path: opts.binPath });
+  const unzip = unzipStream.Extract({ path: opts.binPath });
 
   unzip.on('error', onError);
   unzip.on('close', onSuccess);


### PR DESCRIPTION
The `unzipper` package is broken since Node 20+ (https://github.com/ZJONSSON/node-unzipper/issues/286). This bug causes the bz.exe file to be corrupted on Windows installations. This PR migrated to `unzip-stream` instead.